### PR TITLE
Create peapi_openid.py

### DIFF
--- a/PE96-Later/src/Python3/peapi_openid.py
+++ b/PE96-Later/src/Python3/peapi_openid.py
@@ -1,0 +1,20 @@
+import requests, json
+from pprint import pprint
+
+servurl = 'https://<server address>'
+authurl = servurl+'/auth'
+apiurl = servurl+'/pe/api/StaffMember/Me'
+appid = '<appid>'
+appkey = '<appkey>'
+
+respDisc = requests.get(authurl+'/.well-known/openid-configuration')
+tokenurl = respDisc.json()['token_endpoint']
+auth = (appid,appkey)
+authtype = {'grant_type': 'client_credentials', 'scope': 'pe.api'}
+resptoken = requests.post(tokenurl, data=authtype, auth=auth)
+token = resptoken.json()['access_token']
+apiheader = {'Authorization': 'Bearer ' + token}
+# add the apiheader to PE api requests
+
+respapi = requests.get(apiurl, headers=apiheader)
+pprint(respapi.json())


### PR DESCRIPTION
Python3 example to access the Practice Engine API